### PR TITLE
Fix filename encoding in loadJSON call

### DIFF
--- a/js/base-tool-module.js
+++ b/js/base-tool-module.js
@@ -655,7 +655,7 @@ function baseToolModule () {
 						$win.dialog("open");
 						$wrpDataLoadingMessage.html("<i>Loading...</i>");
 						// Load the chosen module
-						DataUtil.loadJSON(`${urlbase}${sel.filename}`)
+						DataUtil.loadJSON(`${urlbase}${encodeURIComponent(sel.filename)}`)
 							.then(moduleFile => {
 								$wrpDataLoadingMessage.html("");
 								preprocessModuleData(moduleFile);


### PR DESCRIPTION
Some adventures use spaces in their names, this allows those adventures to be imported.