### PR TITLE
Fix missing autoBackup module in 2014 sheet build

### DIFF
--- a/node/build-scripts.js
+++ b/node/build-scripts.js
@@ -273,6 +273,7 @@ const SCRIPTS = {
 		"base-config",
 		"base-tool",
 		"base-tool-module",
+		"base-tool-autobackup",
 		"base-tool-unlock",
 		"base-tool-animator",
 		"base-tool-table",


### PR DESCRIPTION
The merge that introduced a separate SCRIPTS["5et2014"] script list dropped "base-tool-autobackup", so d20plus.autoBackup was never initialized on 2014 sheets while 5etools-bootstrap.js still called d20plus.autoBackup.init() unconditionally, throwing a TypeError on load.