### PR TITLE
Added scaling and offset to defined map regions

### DIFF
--- a/js/5etools/5etools-adventures.js
+++ b/js/5etools/5etools-adventures.js
@@ -509,8 +509,8 @@ function d20plusAdventure () {
 				const xs = r.points.map(p => p[0]);
 				const ys = r.points.map(p => p[1]);
 				areaCentroids[r.area] = [
-					(xs.reduce((a, b) => a + b, 0) / xs.length) * scaleX,
-					(ys.reduce((a, b) => a + b, 0) / ys.length) * scaleY,
+					((xs.reduce((a, b) => a + b, 0) / xs.length) + offsetX / gridScale) * imageScale,
+					((ys.reduce((a, b) => a + b, 0) / ys.length) + offsetY / gridScale) * imageScale,
 				];
 			}
 		});


### PR DESCRIPTION
This centers tokens on their rooms more accurately.

Before:
<img width="1000" height="712" alt="image" src="https://github.com/user-attachments/assets/c3513b70-20b7-4e95-b3b6-4cb3ea33b360" />

After:
<img width="820" height="624" alt="image" src="https://github.com/user-attachments/assets/0ad67d87-c822-4830-84f4-f8a86426e388" />