### PR TITLE
Version number and map token fix

### DIFF
--- a/js/5etools/5etools-adventures.js
+++ b/js/5etools/5etools-adventures.js
@@ -770,9 +770,15 @@ function d20plusAdventure () {
 			// "mapPlayer" entries carry their own title as the generic literal "Player Version"
 			// (5etools schema), so they can't be keyed into `foundryMaps` directly - resolve
 			// via `mapParent.id`, which points back at the sibling "map" entry's real title.
+			// They also carry no `mapRegions` of their own (only the sibling "map" entry does),
+			// so token-placement centroids need the same mapParent fallback.
 			const idToTitle = {};
+			const idToMapRegions = {};
 			mapEntries.forEach(e => {
-				if (e.imageType === "map" && e.id) idToTitle[e.id] = e.title || e.name;
+				if (e.imageType === "map" && e.id) {
+					idToTitle[e.id] = e.title || e.name;
+					if (e.mapRegions?.length) idToMapRegions[e.id] = e.mapRegions;
+				}
 			});
 			const mapObjects = [];
 			for (const e of mapEntries) {
@@ -786,6 +792,9 @@ function d20plusAdventure () {
 				const wallLookupTitle = e.imageType === "mapPlayer" && e.mapParent?.id
 					? idToTitle[e.mapParent.id]
 					: null;
+				if (e.imageType === "mapPlayer" && !e.mapRegions?.length && e.mapParent?.id) {
+					e.mapRegions = idToMapRegions[e.mapParent.id];
+				}
 				mapObjects.push(buildMapObject(e, foundryMaps, paintedGridSize, wallLookupTitle));
 			}
 			if (mapObjects.length) savedMaps = await importMaps(mapObjects);

--- a/js/base/base-util.js
+++ b/js/base/base-util.js
@@ -68,12 +68,22 @@ function baseUtil () {
 
 		const isStreamer = !!d20plus.cfg.get("chat", "streamerChatTag");
 		const scriptName = isStreamer ? "Script" : "betteR20";
+
+		// GitHub's "releases/latest/download/<asset>" URL 302s to an objects.githubusercontent.com
+		// asset that doesn't send Access-Control-Allow-Origin, so the browser blocks it as CORS.
+		// The releases API on api.github.com always sends permissive CORS, so use that instead
+		// whenever B20_REPO_URL points at a GitHub releases download URL.
+		const releaseMatch = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/releases\/latest\/download\/$/i.exec(B20_REPO_URL);
+		const versionUrl = releaseMatch
+			? `https://api.github.com/repos/${releaseMatch[1]}/${releaseMatch[2]}/releases/latest`
+			: `${B20_REPO_URL}betteR20-version`;
+
 		$.ajax({
-			url: `${B20_REPO_URL}betteR20-version`,
+			url: versionUrl,
 			success: (data) => {
-				if (data) {
+				const avail = releaseMatch ? data?.tag_name?.replace(/^v/i, "") : data;
+				if (avail) {
 					const curr = d20plus.version;
-					const avail = data;
 					const cmp = d20plus.ut.cmpVersions(curr, avail);
 					if (cmp < 0) {
 						setTimeout(() => {


### PR DESCRIPTION
This update resolves the version number issue and also adds the missing tokens in the player version of maps imported via the adventure importer.