### PR TITLE
Fix Level Up for Charactermancer-built characters

### DIFF
--- a/js/5etools/2024/5etools-2024-charactermancer.js
+++ b/js/5etools/2024/5etools-2024-charactermancer.js
@@ -2594,6 +2594,17 @@ function d20plus2024Charactermancer () {
 
 			const pages = data?.data?.ruleSystem?.category?.filterAndSortPages;
 			if (Array.isArray(pages)) {
+				// These queries all set showUnownedContent:true (confirmed live), so Roll20's own
+				// response already includes locked/unowned pages (e.g. Artificer for an account
+				// that doesn't own its book) alongside owned ones - "the name is already in
+				// `pages`" does NOT mean "the player already has full access to it". Strip those
+				// locked placeholders out before computing `existing` below, so our own fully-
+				// unlocked (isOwned:true) synthetic version can take their place instead of being
+				// silently skipped as a "duplicate" of content the player can't actually use.
+				for (let i = pages.length - 1; i >= 0; i--) {
+					if (!pages[i]?.book?.isOwned) pages.splice(i, 1);
+				}
+
 				// Deduplicate and label: when multiple entries share a name (e.g. PHB vs XPHB),
 				// append "(SOURCE)" so players can tell them apart.
 				const existing = new Set(pages.map(p => p.name.toLowerCase()));

--- a/js/5etools/2024/5etools-2024-class-import.js
+++ b/js/5etools/2024/5etools-2024-class-import.js
@@ -31,12 +31,32 @@ function d20plus2024ClassImport() {
         // Dragging a class that's already on this character re-levels it instead of creating a
         // duplicate Class block - Roll20's own native "Level Up" button refuses to touch a
         // manually-imported (non-compendium-linked) class, so this is the only way to level one up.
-        const existingClassInt = Object.values(ints).find(i => i.type === "Class" && (i.name || "").toLowerCase() === clss.name.toLowerCase());
+        // A Charactermancer-built class integrant may be named e.g. "Monk (XPHB)" (see
+        // splitDisplayName) while `clss.name` - real class data - is always the bare "Monk", so
+        // strip any such suffix back off the integrant's name before comparing; otherwise this
+        // silently treats an already-present class as brand new and duplicates it.
+        const existingClassEntry = Object.entries(ints).find(([, i]) => i.type === "Class" && classCtx.splitDisplayName(i.name).bareName === clss.name.toLowerCase());
+        const existingClassInt = existingClassEntry ? existingClassEntry[1] : null;
 
-        let startLevel, maxLevel, classId, classChildren;
+        // Ground-truthed against a real Charactermancer-built character: a native Class Level's
+        // parentID/sourceID/classID reference its Class parent's own DICTIONARY KEY, not its
+        // shortID. Those only look interchangeable for integrants we build ourselves, because we
+        // always set shortID === key by construction (see "Native ID Format" in project memory) -
+        // for a native class (dict key is a full UUID, shortID a separate short value), shortID
+        // is simply the wrong value here. `classId` below is therefore the dictionary key, used
+        // for every parentID/sourceID/classID we write on this class's children; `classShortID`
+        // is kept separately, only for our own `_betterR20ClassData` cache bookkeeping (which
+        // import2024ClassLevelUp reads back by shortID, independent of Roll20's own linking).
+        let startLevel, maxLevel, classId, classShortID, classInt, classChildren;
         if (existingClassInt) {
-            classId = existingClassInt.shortID;
-            const existingLevels = Object.values(ints).filter(i => i.type === "Class Level" && i.classID === classId);
+            classId = existingClassEntry[0];
+            classShortID = existingClassInt.shortID;
+            classInt = existingClassInt;
+            // `classID` is our own field name for integrants we build by hand - a Class Level
+            // integrant Roll20's native builder created (from a Charactermancer-picked class)
+            // only ever sets the universal `parentID` every integrant type in this schema uses.
+            // Check both so this works regardless of which path built the level.
+            const existingLevels = Object.values(ints).filter(i => i.type === "Class Level" && (i.parentID === classId || i.classID === classId));
             const currentMax = existingLevels.length ? Math.max(...existingLevels.map(l => l.level)) : 0;
 
             const levelInput = prompt(`${clss.name} is already on this character at level ${currentMax}. Level up to what level? (${currentMax + 1}-20)`, String(Math.min(20, currentMax + 1)));
@@ -87,6 +107,7 @@ function d20plus2024ClassImport() {
         if (!existingClassInt) {
             const {id: newClassId, base: classBase} = makeBase("Class");
             classId = newClassId;
+            classShortID = newClassId; // dict key === shortID for integrants we build ourselves
             ints[classId] = {
                 ...classBase,
                 name: clss.name,
@@ -98,6 +119,7 @@ function d20plus2024ClassImport() {
                 cascades: {},
                 relations: {},
             };
+            classInt = ints[classId];
         }
 
         const avgHP = Math.ceil((clss.hd.faces + 1) / 2);
@@ -236,7 +258,7 @@ function d20plus2024ClassImport() {
             ints[lvlId].childIDs = JSON.stringify(lvlChildren);
         }
 
-        ints[classId].childIDs = JSON.stringify(classChildren);
+        classInt.childIDs = JSON.stringify(classChildren);
 
         // Cache the raw class JSON so a later level-up (e.g. via the hijacked native Level Up
         // button, which has no drag payload to work from) can re-run this same import logic
@@ -250,7 +272,7 @@ function d20plus2024ClassImport() {
         if (cacheAttr) {
             try { cacheData = JSON.parse(cacheAttr.get("current") || "{}"); } catch (e) { cacheData = {}; }
         }
-        cacheData[classId] = clss;
+        cacheData[classShortID] = clss;
         if (cacheAttr) {
             cacheAttr.set("current", JSON.stringify(cacheData));
             cacheAttr.save();
@@ -319,8 +341,8 @@ function d20plus2024ClassImport() {
         if (!store) return;
 
         const ints = store.integrants.integrants;
-        const classInts = Object.values(ints).filter(i => i.type === "Class");
-        if (!classInts.length) {
+        const classEntries = Object.entries(ints).filter(([, i]) => i.type === "Class");
+        if (!classEntries.length) {
             alert("No BetteR20-imported class found on this character.");
             return;
         }
@@ -331,42 +353,77 @@ function d20plus2024ClassImport() {
             try { rawData = JSON.parse(cacheAttr.get("current") || "{}"); } catch (e) { rawData = {}; }
         }
 
-        let chosen = classInts[0];
-        if (classInts.length > 1) {
-            const names = classInts.map(c => c.name).join(", ");
-            const input = prompt(`Multiple classes found (${names}). Which one do you want to level up?`, classInts[0].name);
+        let [chosenKey, chosen] = classEntries[0];
+        if (classEntries.length > 1) {
+            const names = classEntries.map(([, c]) => c.name).join(", ");
+            const input = prompt(`Multiple classes found (${names}). Which one do you want to level up?`, chosen.name);
             if (input === null) return;
-            const match = classInts.find(c => c.name.toLowerCase() === input.trim().toLowerCase());
+            const match = classEntries.find(([, c]) => c.name.toLowerCase() === input.trim().toLowerCase());
             if (!match) {
                 alert(`No class named "${input}" found on this character.`);
                 return;
             }
-            chosen = match;
+            [chosenKey, chosen] = match;
         }
 
-        const cachedClss = rawData[chosen.shortID];
+        // The Charactermancer disambiguates same-named classes from different sources by baking
+        // " (SOURCE)" straight into the page's own name (e.g. "Monk (XPHB)") whenever more than
+        // one source offers a class with that name - real class/subclass data has no such
+        // suffix (source is its own field), so a raw name match against it would never hit.
+        // Strip the suffix back off before matching, and prefer whichever candidate's own
+        // .source matches the extracted hint when more than one class shares the bare name.
+        const {bareName, sourceHint} = classCtx.splitDisplayName(chosen.name);
+
+        let cachedClss = rawData[chosen.shortID];
         if (!cachedClss) {
-            alert(`"${chosen.name}" wasn't imported via BetteR20 (or its data wasn't cached) - drag the class card onto this character again to level it up instead.`);
+            // Characters built via the Charactermancer never went through import2024Class, so
+            // nothing was ever cached for them (there's no drag-and-drop payload to cache from
+            // in that flow) - fall back to the site's own already-loaded class data instead of
+            // just giving up. This is the same data the Charactermancer's own class picker is
+            // built from, so it's a reliable source for anything the player could have picked.
+            try {
+                const allClasses = await DataLoader.pCacheAndGetAllSite("class");
+                const candidates = (allClasses || []).filter(c => (c.name || "").toLowerCase() === bareName);
+                cachedClss = (sourceHint && candidates.find(c => (c.source || "").toLowerCase() === sourceHint)) || candidates[0];
+            } catch (e) { /* ignore - handled by the null check below */ }
+        }
+        if (!cachedClss) {
+            alert(`Couldn't find data for "${chosen.name}" to level it up - it may be from a source that's no longer loaded.`);
             return;
         }
 
         await d20plus.importer.import2024Class(charModel, {Vetoolscontent: cachedClss}, store);
 
         // Also bring a cached subclass up to the class's new level, so leveling up the class
-        // is a single action instead of two separate re-drags.
-        const newLevels = Object.values(ints).filter(i => i.type === "Class Level" && i.classID === chosen.shortID);
+        // is a single action instead of two separate re-drags. As with import2024Class, this
+        // needs the class's dictionary key (chosenKey), not its shortID, to match a native
+        // Class Level's parentID/classID.
+        const newLevels = Object.values(ints).filter(i => i.type === "Class Level" && (i.parentID === chosenKey || i.classID === chosenKey));
         const newMax = newLevels.length ? Math.max(...newLevels.map(l => l.level)) : 0;
 
         if (newMax) {
             const subclassCacheAttr = charModel.attribs.find(a => a.get("name") === "_betterR20SubclassData");
+            let subclassRawData = {};
             if (subclassCacheAttr) {
-                let subclassRawData = {};
                 try { subclassRawData = JSON.parse(subclassCacheAttr.get("current") || "{}"); } catch (e) { subclassRawData = {}; }
+            }
 
-                const cachedSc = subclassRawData[chosen.shortID];
-                if (cachedSc) {
-                    await d20plus.importer.import2024Subclass(charModel, {Vetoolscontent: cachedSc}, newMax, store);
+            let cachedSc = subclassRawData[chosen.shortID];
+            if (!cachedSc) {
+                // Same reasoning as the class fallback above - match the character's existing
+                // Subclass integrant (whichever way it got there) against the site's own data.
+                const subclassInt = Object.values(ints).find(i => i.type === "Subclass" && i.parentID === chosenKey);
+                if (subclassInt) {
+                    try {
+                        const allSubclasses = await DataLoader.pCacheAndGetAllSite("subclass");
+                        cachedSc = (allSubclasses || []).find(sc => (sc.className || "").toLowerCase() === bareName
+                            && (sc.shortName || sc.name || "").toLowerCase() === subclassInt.name.toLowerCase());
+                    } catch (e) { /* ignore - subclass level-up is best-effort */ }
                 }
+            }
+
+            if (cachedSc) {
+                await d20plus.importer.import2024Subclass(charModel, {Vetoolscontent: cachedSc}, newMax, store);
             }
         }
 

--- a/js/5etools/2024/5etools-2024-subclass-import.js
+++ b/js/5etools/2024/5etools-2024-subclass-import.js
@@ -52,11 +52,16 @@ function d20plus2024SubclassImport() {
 			}
 
 			const ints = store.integrants.integrants;
-			const classInt = Object.values(ints).find(i => i.type === "Class" && (i.name || "").toLowerCase() === (sc.className || "").toLowerCase());
-			if (!classInt) {
+			// A Charactermancer-built class integrant may be named e.g. "Monk (XPHB)" while
+			// sc.className (real subclass data) is always the bare "Monk" - strip the suffix
+			// back off before comparing (see splitDisplayName), or this false-negatives and
+			// tells the player to import a class that's already on the character.
+			const classEntry = Object.entries(ints).find(([, i]) => i.type === "Class" && subclassCtx.splitDisplayName(i.name).bareName === (sc.className || "").toLowerCase());
+			if (!classEntry) {
 				alert(`Import the ${sc.className} class onto this character before adding ${displayName}.`);
 				return;
 			}
+			const [classKey, classInt] = classEntry;
 
 			let pos = subclassCtx.getNextArrayPos(store);
 			const renderer = Renderer.get().setBaseUrl(LINK_BASE_URL);
@@ -66,7 +71,14 @@ function d20plus2024SubclassImport() {
 			// instead of creating a duplicate one, same as import2024Class does for the class
 			// itself. A different-named subclass already present is left alone rather than
 			// silently merged into - flag it instead.
-			let subclassInt = Object.values(ints).find(i => i.type === "Subclass" && i.parentID === classInt.shortID);
+			// Ground-truthed against a real Charactermancer-built character (see import2024Class):
+			// a native integrant's parentID/sourceID references its parent's dictionary key, not
+			// its shortID - those only coincide for integrants we build ourselves. classKey/
+			// subclassKey below are dictionary keys, used for every parentID/sourceID write;
+			// classInt.shortID/subclassInt.shortID are never used for linking purposes here.
+			let subclassKey, subclassInt;
+			const existingSubclassEntry = Object.entries(ints).find(([, i]) => i.type === "Subclass" && i.parentID === classKey);
+			if (existingSubclassEntry) [subclassKey, subclassInt] = existingSubclassEntry;
 			if (subclassInt && subclassInt.name.toLowerCase() !== displayName.toLowerCase()) {
 				alert(`${classInt.name} already has a different subclass ("${subclassInt.name}") on this character - remove it before adding ${displayName}.`);
 				return;
@@ -76,27 +88,27 @@ function d20plus2024SubclassImport() {
 			if (subclassInt) {
 				subclassChildren = JSON.parse(subclassInt.childIDs || "[]");
 			} else {
-				const {id: subclassId, base: subclassBase} = subclassCtx.makeIntegrantBase("Subclass", pos++);
+				const {id: newSubclassId, base: subclassBase} = subclassCtx.makeIntegrantBase("Subclass", pos++);
 				subclassBase.source = "Class";
-				ints[subclassId] = {
+				ints[newSubclassId] = {
 					...subclassBase,
 					name: displayName,
 					recordName: displayName,
-					parentID: classInt.shortID,
-					sourceID: classInt.shortID,
+					parentID: classKey,
+					sourceID: classKey,
 					childIDs: "[]",
 					cascades: {},
 					relations: {},
 				};
-				subclassInt = ints[subclassId];
+				subclassInt = ints[newSubclassId];
+				subclassKey = newSubclassId; // dict key === shortID for integrants we build ourselves
 
 				const classChildren = JSON.parse(classInt.childIDs || "[]");
-				classChildren.push(subclassId);
+				classChildren.push(newSubclassId);
 				classInt.childIDs = JSON.stringify(classChildren);
 
 				subclassChildren = [];
 			}
-			const subclassId = subclassInt.shortID;
 
 			// Feature names already attached, so a re-import doesn't duplicate features
 			// already granted from an earlier, lower-level import.
@@ -132,8 +144,8 @@ function d20plus2024SubclassImport() {
 					name: feature.name,
 					recordName: feature.name,
 					description,
-					parentID: subclassId,
-					sourceID: subclassId,
+					parentID: subclassKey,
+					sourceID: subclassKey,
 					childIDs: "[]",
 					cascades: {},
 					relations: {},

--- a/js/5etools/2024/5etools-2024-utils.js
+++ b/js/5etools/2024/5etools-2024-utils.js
@@ -89,5 +89,18 @@ function d20plus2024Utils() {
 		const current = JSON.parse(store[section][key] || "[]");
 		store[section][key] = JSON.stringify([...current, ...ids]);
 	};
+
+	// The Charactermancer bakes a " (SOURCE)" suffix into a page's own name whenever more than
+	// one source offers something with that name (see the `inject()` dedup logic in
+	// 5etools-2024-charactermancer.js) - real 5etools data has no such suffix, so anything
+	// matching a Charactermancer-built integrant's name against real data (by class/subclass
+	// name) needs this split back out first, on both the class and subclass import paths.
+	// Returns lower-cased parts for direct use in case-insensitive comparisons.
+	ctx2024.splitDisplayName = function (name) {
+		const m = /^(.*?)\s*\(([^()]+)\)$/.exec(name || "");
+		return m
+			? {bareName: m[1].toLowerCase(), sourceHint: m[2].toLowerCase()}
+			: {bareName: (name || "").toLowerCase(), sourceHint: null};
+	};
 }
 SCRIPT_EXTENSIONS.push(d20plus2024Utils);


### PR DESCRIPTION
- Level up falls back to site-wide class/subclass data when no per-character cache exists, since Charactermancer never wrote one
- Strip the Charactermancer's " (SOURCE)" name-disambiguation suffix before matching class/subclass data, or matches silently fail
- Fix class/subclass linking to use each integrant's dictionary key instead of its shortID - only interchangeable for integrants we build ourselves, not native ones, and using shortID caused duplicate class blocks and incorrect level counts
- Stop skipping Charactermancer content injection for names Roll20 already returned locked/unowned (showUnownedContent:true means "returned" isn't "owned")